### PR TITLE
fix: switch Docker layer cache from GHA to registry backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,12 +57,8 @@ jobs:
             dotenv=.env.production
           build-args: |
             ENV_HASH=${{ hashFiles('.env.production') }}
-          cache-from: |
-            type=gha,scope=app
-            type=gha,scope=shared
-          cache-to: |
-            type=gha,mode=max,scope=app
-            type=gha,mode=max,scope=shared
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-app
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-app,mode=max
 
       - name: Extract metadata for SSR image
         id: meta-ssr
@@ -87,9 +83,5 @@ jobs:
             dotenv=.env.production
           build-args: |
             ENV_HASH=${{ hashFiles('.env.production') }}
-          cache-from: |
-            type=gha,scope=ssr
-            type=gha,scope=shared
-          cache-to: |
-            type=gha,mode=max,scope=ssr
-            type=gha,mode=max,scope=shared
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-ssr
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-ssr,mode=max


### PR DESCRIPTION
## Summary

- Same root cause and fix as `pingcrm-react-inertia-laravel#33`: the last 3 builds on `main` failed at "exporting to GitHub Actions Cache" with `failed to reserve cache`, even though the image itself had already been built and pushed successfully just before that step.
- Because `docker/build-push-action` treats the image push and cache export as one atomic operation, the cache failure aborts the whole job — the SSR image never even starts building, and no `run-N-*` tags land on ghcr, blocking Flux Image Automation entirely.
- Switches `cache-from`/`cache-to` from `type=gha` to `type=registry`, storing the build cache as a tagged image in the same ghcr.io repo (`buildcache-app` / `buildcache-ssr`) instead of relying on the currently-flaky GitHub Actions cache API.

## Test plan

- [ ] Merging this PR should let the build complete and produce `run-N-app`/`run-N-ssr` tags.