### PR TITLE
chore: adopt pingcrm build model (runner-built assets, minimal build secret)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 **/.DS_Store
+**/*.log
+**/*.md
+.git
 .vault-password
 .ddev
 .github
@@ -6,10 +9,14 @@
 .idea
 .config
 .data
+tests
+docs
+node_modules
+vendor
 Dockerfile
 compose*.yaml
 
-# Environment files with secrets
+# Environment files with secrets (keep the templates only)
 .env
 .env.*
 !.env.example

--- a/.env.production.dist
+++ b/.env.production.dist
@@ -1,3 +1,20 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# BUILD-only environment — template for the GitHub Actions secret ENV_FILE_BASE64.
+#
+# The CI build (.github/workflows/build.yml) decodes this into `.env`, runs
+# `php artisan key:generate` (throwaway key), builds the Vite assets + SSR bundle
+# (`bun run build:ssr`, which also runs Wayfinder route generation), then deletes
+# the `.env`. It is NEVER baked into the image.
+#
+# Therefore ONLY the variables the asset build needs live here — no runtime
+# secrets (DB, Redis, Mail, backups, Reverb…). Runtime configuration is injected
+# in the cluster (a SOPS-encrypted Secret mounted as .env + `env:` overrides),
+# never from this file.
+#
+# Regenerate the secret after editing:
+#   base64 -i .env.production | gh secret set ENV_FILE_BASE64 -R fouteox/fadogen
+# ─────────────────────────────────────────────────────────────────────────────
+
 APP_NAME=Fadogen
 APP_ENV=production
 APP_KEY=
@@ -5,70 +22,4 @@ APP_DEBUG=false
 APP_HOST=fadogen.app
 APP_URL="https://${APP_HOST}"
 
-NIGHTWATCH_TOKEN=
-NIGHTWATCH_REQUEST_SAMPLE_RATE=0.1
-
-APP_MAINTENANCE_DRIVER=file
-# APP_MAINTENANCE_STORE=database
-
-# PHP_CLI_SERVER_WORKERS=4
-
-BCRYPT_ROUNDS=12
-
-LOG_CHANNEL=stack
-LOG_STACK=daily,errorlog
-LOG_DEPRECATIONS_CHANNEL=null
-LOG_LEVEL=debug
-
-DB_CONNECTION=pgsql
-DB_HOST=pgsql
-DB_PORT=5432
-DB_DATABASE=fadogen
-DB_USERNAME=fadogen
-DB_PASSWORD="fadogen"
-
-BROADCAST_CONNECTION=reverb
-
-CACHE_STORE=redis
-CACHE_PREFIX="${APP_NAME}_"
-
-QUEUE_CONNECTION=redis
-
-SESSION_DRIVER=redis
-SESSION_LIFETIME=180
-SESSION_COOKIE="_${APP_NAME}"
-
-MEMCACHED_HOST=127.0.0.1
-
-REDIS_HOST=valkey
-REDIS_PASSWORD="fadogen"
-
-MAIL_MAILER=smtp
-MAIL_DRIVER=smtp
-MAIL_HOST=smtp.googlemail.com
-MAIL_PORT=465
-MAIL_USERNAME=
-MAIL_PASSWORD=
-MAIL_ENCRYPTION=ssl
-MAIL_FROM_ADDRESS=
-MAIL_FROM_NAME="${APP_NAME}"
-
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_DEFAULT_REGION=eu-west-3
-AWS_BUCKET=assets
-AWS_ENDPOINT=
-
 VITE_APP_NAME="${APP_NAME}"
-
-REVERB_APP_ID=999999
-REVERB_APP_KEY=changemeabcde1234567
-REVERB_APP_SECRET=changeme123456789abcde
-REVERB_HOST="${APP_HOST}"
-REVERB_PORT=443
-REVERB_SCHEME=https
-
-VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
-VITE_REVERB_HOST="${REVERB_HOST}"
-VITE_REVERB_PORT="${REVERB_PORT}"
-VITE_REVERB_SCHEME="${REVERB_SCHEME}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,8 @@ jobs:
           target: app
           tags: ${{ steps.meta-app.outputs.tags }}
           labels: ${{ steps.meta-app.outputs.labels }}
-          cache-from: type=gha,scope=app
-          cache-to: type=gha,mode=max,scope=app
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-app
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-app,mode=max
 
       - name: Extract metadata for SSR image
         id: meta-ssr
@@ -101,8 +101,8 @@ jobs:
           target: ssr
           tags: ${{ steps.meta-ssr.outputs.tags }}
           labels: ${{ steps.meta-ssr.outputs.labels }}
-          cache-from: type=gha,scope=ssr
-          cache-to: type=gha,mode=max,scope=ssr
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-ssr
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-ssr,mode=max
 
       - name: Cleanup pre-build env
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   pull_request:
     types: [closed]
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ${{ vars.SYSTEM_ARCH == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -21,8 +22,33 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Create .env.production file
-        run: echo "${{ secrets.ENV_FILE_BASE64 }}" | base64 -d > .env.production
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: dom, curl, libxml, mbstring, zip, pdo, bcmath, intl
+          coverage: none
+          tools: composer:v2
+
+      - name: Install Composer dependencies (no-dev — matches production)
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: '--no-dev'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3'
+
+      # Assets are built on the runner (not in the Dockerfile): the env is
+      # decoded, a throwaway APP_KEY is generated, assets + SSR bundle are built,
+      # then the env is deleted. No runtime secret ever reaches the image.
+      - name: Load env and pre-build assets
+        run: |
+          echo "${{ secrets.ENV_FILE_BASE64 }}" | base64 -d > .env
+          php artisan key:generate --force --ansi
+          bun install --frozen-lockfile
+          bun run build:ssr
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -53,16 +79,8 @@ jobs:
           target: app
           tags: ${{ steps.meta-app.outputs.tags }}
           labels: ${{ steps.meta-app.outputs.labels }}
-          secret-files: |
-            dotenv=.env.production
-          build-args: |
-            ENV_HASH=${{ hashFiles('.env.production') }}
-          cache-from: |
-            type=gha,scope=app
-            type=gha,scope=shared
-          cache-to: |
-            type=gha,mode=max,scope=app
-            type=gha,mode=max,scope=shared
+          cache-from: type=gha,scope=app
+          cache-to: type=gha,mode=max,scope=app
 
       - name: Extract metadata for SSR image
         id: meta-ssr
@@ -83,13 +101,9 @@ jobs:
           target: ssr
           tags: ${{ steps.meta-ssr.outputs.tags }}
           labels: ${{ steps.meta-ssr.outputs.labels }}
-          secret-files: |
-            dotenv=.env.production
-          build-args: |
-            ENV_HASH=${{ hashFiles('.env.production') }}
-          cache-from: |
-            type=gha,scope=ssr
-            type=gha,scope=shared
-          cache-to: |
-            type=gha,mode=max,scope=ssr
-            type=gha,mode=max,scope=shared
+          cache-from: type=gha,scope=ssr
+          cache-to: type=gha,mode=max,scope=ssr
+
+      - name: Cleanup pre-build env
+        if: always()
+        run: rm -f .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ USER root
 RUN install-php-extensions bcmath
 
 ############################################
-# Builder Stage
+# Builder Stage (vendor only — JS assets are pre-built on the CI runner,
+# so the build needs no .env secret and never bakes one into the image)
 ############################################
 FROM base AS builder
-
-COPY --from=oven/bun:1.3-debian /usr/local/bin/bun /usr/local/bin/bun
 
 COPY --link composer.json composer.lock ./
 
@@ -26,19 +25,9 @@ RUN composer install \
     --no-scripts \
     --audit
 
-COPY --link package*.json bun.lock* ./
-
-RUN bun install --frozen-lockfile
-
 COPY --link . .
 
 RUN composer dump-autoload --classmap-authoritative --no-dev
-
-ARG ENV_HASH
-RUN --mount=type=secret,id=dotenv \
-    echo "Build with ENV_HASH=${ENV_HASH}" && \
-    set -a && . /run/secrets/dotenv && set +a && \
-    bun run build:ssr
 
 ############################################
 # App Image
@@ -47,9 +36,8 @@ FROM base AS app
 
 COPY --link --chown=33:33 --from=builder /var/www/html/vendor ./vendor
 
+# The build context already carries public/build (pre-built on the runner).
 COPY --link --chown=33:33 . .
-
-COPY --link --chown=33:33 --from=builder /var/www/html/public/build ./public/build
 
 RUN mkdir -p \
     storage/logs \
@@ -70,7 +58,8 @@ FROM oven/bun:1.3-debian AS ssr
 
 WORKDIR /app
 
-COPY --from=builder /var/www/html/bootstrap/ssr ./bootstrap/ssr
+# bootstrap/ssr is produced by `bun run build:ssr` on the runner.
+COPY --link bootstrap/ssr ./bootstrap/ssr
 
 EXPOSE 13714
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # Fadogen - Build and deploy applications easily.
 
 Fadogen is a tool that allows you to create applications and deploy them very easily. Think of it as the shadcn of deployment. No tools are required (except ddev).
+
+## Building & deployment
+
+Container images are built and pushed to GHCR by
+[`.github/workflows/build.yml`](.github/workflows/build.yml) on every merge to
+`main` (a `-app` image and a `-ssr` image).
+
+Front-end assets are pre-built on the CI runner (`bun run build:ssr`), so the
+Dockerfile `builder` stage only installs PHP dependencies and **no `.env` secret
+is ever baked into the image**.
+
+The workflow needs a single repository secret, **`ENV_FILE_BASE64`** — the
+base64 of a **build-only** `.env` (see [`.env.production.dist`](.env.production.dist)).
+It holds only what the asset build needs (app name/URL and `VITE_*`); the
+`APP_KEY` is generated on the fly during the build, and **no runtime secret**
+(database, cache, mail…) belongs here. Runtime configuration is provided by the
+deployment platform (a mounted, encrypted `.env` plus environment overrides).
+
+Regenerate the secret after editing the template:
+
+```sh
+base64 -i .env.production | gh secret set ENV_FILE_BASE64 -R fouteox/fadogen
+```


### PR DESCRIPTION
## What
Aligns fadogen's image build with the cleaner pingcrm model:
- Front-end assets are built **on the CI runner** (`bun run build:ssr`) with a **throwaway `APP_KEY`** (`php artisan key:generate`), and the `.env` is deleted afterwards — instead of mounting the full production `.env` as a BuildKit secret inside the Dockerfile.
- The Dockerfile `builder` stage is now **vendor-only**; no `.env` is ever baked into the image.
- `ENV_FILE_BASE64` is reduced to a **build-only** template (`.env.production.dist`): app name/URL + `VITE_*` only — no runtime secrets (DB/Redis/Mail/backups). The repository secret was already updated to match.
- `.dockerignore` now excludes `node_modules`/`vendor`; the README documents the model.

## Why
The build secret previously carried every runtime secret (DB/Redis/Mail/backup credentials) that the asset build never uses — a least-privilege cleanup. Wayfinder boots Laravel only to list routes (it connects to nothing), so the build needs just app config + `VITE_APP_NAME`.

## Validation
- CI build on this branch: ✅ success.
- Image contents verified: `run-5-app` ships `public/build/manifest.json` + `vendor`; `run-5-ssr` ships `bootstrap/ssr/ssr.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)