### PR TITLE
ci: weekly security rebuild + dependabot on the build supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot: version updates for the CI supply chain only (Dockerfile FROMs
+# and GitHub Actions). Composer/npm version noise is deliberately excluded —
+# security-driven PRs for those come from Dependabot security updates,
+# enabled at the repository level.
+#
+# Note: the serversideup/php FROM is ARG-parameterized (PHP_VERSION), which
+# Dependabot cannot follow — PHP version bumps stay deliberate. Base image
+# FRESHNESS for the same tag is covered by the weekly scheduled rebuild in
+# build.yml (no-cache + pull).
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ on:
     types: [closed]
     branches: [main]
   workflow_dispatch:
+  schedule:
+    # Weekly security rebuild (Mondays 04:00 UTC): base images ship security
+    # fixes under the SAME tag — they only reach us on a fresh build. The
+    # run produces new run-N tags, so Flux Image Automation rolls it out.
+    - cron: '0 4 * * 1'
 
 env:
   REGISTRY: ghcr.io
@@ -12,7 +17,7 @@ env:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ${{ vars.SYSTEM_ARCH == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -79,6 +84,12 @@ jobs:
           target: app
           tags: ${{ steps.meta-app.outputs.tags }}
           labels: ${{ steps.meta-app.outputs.labels }}
+          # Scheduled runs bypass the layer cache and re-pull bases: a cached
+          # rebuild would reuse the old (potentially vulnerable) layers and
+          # defeat the purpose. cache-to still refreshes the cache for the
+          # week's push builds.
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-app
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-app,mode=max
 
@@ -101,6 +112,8 @@ jobs:
           target: ssr
           tags: ${{ steps.meta-ssr.outputs.tags }}
           labels: ${{ steps.meta-ssr.outputs.labels }}
+          no-cache: ${{ github.event_name == 'schedule' }}
+          pull: ${{ github.event_name == 'schedule' }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-ssr
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-ssr,mode=max
 


### PR DESCRIPTION
## What

- **Weekly scheduled rebuild** (Mondays 04:00 UTC) of both images with `no-cache: true` + `pull: true`: base images (serversideup/php, oven/bun) ship security fixes under the same tag — they only reach production on a fresh build. The scheduled run produces new `run-N` tags, so Flux Image Automation deploys the rebuilt images automatically (rolling, zero downtime).
- **Dependabot** on the build supply chain: Dockerfile FROMs + GitHub Actions, weekly. Composer/npm version updates are deliberately excluded to avoid noise; security-driven PRs for those are covered by repository-level Dependabot security updates (now enabled).

## Notes

- The `serversideup/php` FROM is ARG-parameterized (`PHP_VERSION`) which Dependabot cannot follow — PHP bumps stay deliberate; tag freshness is what the weekly rebuild covers.
- Push builds keep using the registry layer cache unchanged; the scheduled run refreshes that cache for the week.

Part of the homelab updates work (brick 5): Renovate/Flux keep third-party images current, Trivy flags CVEs in running workloads — this closes the loop for our own images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)