### PR TITLE
ci: cover bun dependencies with grouped monthly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,17 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    groups:
+      actions:
+        patterns: ["*"]
+  # Dependabot security updates do NOT support bun yet (alerts fire from
+  # bun.lock, but no auto-fix PR — GitHub changelog, planned). Compensation:
+  # one grouped monthly version-update PR keeps the JS lockfile fresh.
+  # Composer needs no equivalent: its security updates are fully supported.
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      js-dependencies:
+        patterns: ["*"]


### PR DESCRIPTION
Follow-up to #12, closing the one real gap found while auditing the Dependabot setup:

- **bun security updates are not supported by Dependabot yet** ([changelog](https://github.blog/changelog/2025-02-13-dependabot-version-updates-now-support-the-bun-package-manager-ga/) — version updates GA, security auto-fix planned). A CVE in a JS dependency would raise an alert but no fix PR. Compensation: one grouped **monthly** version-update PR for the whole JS lockfile.
- github-actions bumps grouped into a single PR (less noise).

Composer is unchanged: its security updates are fully supported, so version-update noise stays excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)