### PR TITLE
chore: pin base images by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,11 @@
 # security-driven PRs for those come from Dependabot security updates,
 # enabled at the repository level.
 #
-# Note: the serversideup/php FROM is ARG-parameterized (PHP_VERSION), which
-# Dependabot cannot follow — PHP version bumps stay deliberate. Base image
-# FRESHNESS for the same tag is covered by the weekly scheduled rebuild in
-# build.yml (no-cache + pull).
+# Note: both FROMs are digest-pinned — Dependabot keeps tag and digest in
+# sync, so every upstream rebuild of the base lands as a reviewable PR.
+# PHP version bumps stay deliberate (Dockerfile + setup-php + composer.json
+# move together). The weekly scheduled rebuild in build.yml still refreshes
+# what RUN layers fetch at build time (install-php-extensions, composer).
 version: 2
 updates:
   - package-ecosystem: docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-ARG PHP_VERSION=8.5
-
 ############################################
 # Base Stage
 ############################################
-FROM serversideup/php:${PHP_VERSION}-frankenphp AS base
+# Digest-pinned (supply-chain): builds are reproducible and every upstream
+# rebuild of the tag lands as a reviewable Dependabot PR (tag + digest kept
+# in sync). PHP version bumps stay deliberate: Dockerfile + setup-php in
+# build.yml + composer.json must move together.
+FROM serversideup/php:8.5-frankenphp@sha256:a0f4447da7612f9bca3c982d0cf33a607cbddf828f4b96a44bfa9f6f037007b6 AS base
 
 USER root
 
@@ -54,7 +56,7 @@ USER www-data
 ############################################
 # SSR Image
 ############################################
-FROM oven/bun:1.3-debian AS ssr
+FROM oven/bun:1.3-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a0277a8f939ae4dfc9db6f AS ssr
 
 WORKDIR /app
 


### PR DESCRIPTION
Supply-chain hardening follow-up to #12/#18:

- `serversideup/php:8.5-frankenphp` and `oven/bun:1.3-debian` are now **digest-pinned** (multi-arch manifest-list digests, valid for the arm64 runner). Builds become reproducible, and every upstream rebuild of these tags lands as a reviewable Dependabot PR (tag+digest kept in sync) instead of arriving silently.
- The vestigial `PHP_VERSION` ARG is removed — it was never overridden anywhere, and a PHP bump is a coordinated change (Dockerfile + `setup-php` in build.yml + composer.json) that should stay deliberate.
- The weekly scheduled rebuild keeps its purpose: RUN layers still fetch at build time (`install-php-extensions`, `composer install`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)