### PR TITLE
chore: upgrade Symfony YAML to 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel/wayfinder": "^0.1.12",
         "league/flysystem-aws-s3-v3": "^3.0",
         "spatie/laravel-data": "^4.13",
-        "symfony/yaml": "^7.2"
+        "symfony/yaml": "^8.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29aeebaaca71e9a602f2665982c04684",
+    "content-hash": "490a91847adcdca1e5bc304264752478",
     "packages": [
         {
             "name": "archtechx/enums",
@@ -10142,28 +10142,28 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.14",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc"
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8f328665ace2370d1e10645b807ba1646dc7dcc",
-                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/8e4cdd4311683516be06944f4b85244063cdb886",
+                "reference": "8e4cdd4311683516be06944f4b85244063cdb886",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<6.4"
+                "symfony/console": "<7.4"
             },
             "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -10194,7 +10194,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.14"
+                "source": "https://github.com/symfony/yaml/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -10214,7 +10214,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-08T20:24:16+00:00"
+            "time": "2026-06-09T11:06:24+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",


### PR DESCRIPTION
## Summary

- upgrade the direct symfony/yaml constraint from 7.2 to 8.1
- lock symfony/yaml 8.1.1 without changing any other package
- align the final direct Symfony dependency with the Symfony 8.1 graph installed by Laravel 13

Supersedes #34, whose Composer artifact failed and does not include a lockfile update.

## Compatibility

- the application has no direct Symfony YAML API usage
- Laravel Roster and Sail both declare Symfony YAML 8 support
- the Symfony 8 YAML breaking change for duplicate null mapping keys is not used by this project

## Validation

- vendor/bin/pint --dirty
- composer validate --strict --no-interaction
- composer install --no-interaction
- composer audit --no-interaction
- composer test:types -- --no-progress --no-interaction
- php artisan test (10 tests, 18 assertions)
- php artisan about
- php artisan route:list
- vp check
- vp run build:ssr
- git diff --check