### PR TITLE
Remove production secrets from image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,16 @@ jobs:
           node-version: '24'
           cache: true
 
-      # Assets are built on the runner (not in the Dockerfile): the env is
-      # decoded, a throwaway APP_KEY is generated, assets + SSR bundle are built,
-      # then the env is deleted. No runtime secret ever reaches the image.
-      - name: Load env and pre-build assets
+      # Assets are built from the versioned example environment. The only key
+      # needed by Laravel is generated for this job and discarded afterwards;
+      # CI never receives the production environment.
+      - name: Prepare isolated env and pre-build assets
+        env:
+          APP_ENV: production
+          APP_DEBUG: 'false'
         run: |
-          echo "${{ secrets.ENV_FILE_BASE64 }}" | base64 -d > .env
+          umask 077
+          cp .env.example .env
           php artisan key:generate --force --ansi
           vp install --frozen-lockfile
           vp run build:ssr
@@ -194,6 +198,6 @@ jobs:
               throw new Error(`Flux webhook returned HTTP ${response.status}: ${await response.text()}`)
             }
 
-      - name: Cleanup pre-build env
+      - name: Cleanup isolated build env
         if: always()
         run: rm -f .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Reject production env secrets in workflows
+        run: |
+          forbidden='ENV_FILE_'
+          if git grep -n "${forbidden}BASE64" -- .github/workflows; then
+            echo '::error::Production runtime environments must never be CI build inputs.'
+            exit 1
+          fi
+
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:


### PR DESCRIPTION
## What changed

- build assets from the versioned `.env.example` instead of decoding the production `ENV_FILE_BASE64` secret;
- generate a job-local Laravel application key with restrictive file permissions;
- force production mode while keeping runtime secrets exclusively in SOPS/Kubernetes.

## Security outcome

The build job no longer receives the production environment. The existing digest-first push, keyless Cosign signature, provenance, SBOM and OIDC Flux notification remain unchanged.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `vp run types`
- `vp run lint:check`
- `vp run format:check`