### PR TITLE
Preserve frozen Vite+ installs in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           node-version: '24'
           cache: true
+          run-install: false
 
       # Assets are built from the versioned example environment. The only key
       # needed by Laravel is generated for this job and discarded afterwards;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           node-version: '24'
           cache: true
+          run-install: false
 
       - name: Prepare application
         run: |


### PR DESCRIPTION
## What changed

- Disable the implicit dependency installation performed by `voidzero-dev/setup-vp` in both CI and image-build workflows.
- Keep the existing explicit `vp install --frozen-lockfile` steps as the only installers.

## Why

The pinned setup-vp action defaults `run-install` to true. That implicit install happens before the repository's frozen install and may mutate dependency state, weakening lockfile enforcement.

## Validation

- actionlint on both changed workflows
- `git diff --check`