### PR TITLE
Fix GitHub attestation storage metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ${{ vars.SYSTEM_ARCH == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write
@@ -148,6 +149,7 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-app.outputs.digest }}
           push-to-registry: true
+          create-storage-record: false
 
       - name: Attest SSR image with GitHub
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
@@ -155,6 +157,7 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-ssr.outputs.digest }}
           push-to-registry: true
+          create-storage-record: false
 
       - name: Verify GitHub artifact attestations
         shell: bash


### PR DESCRIPTION
## What changed

- grant the `artifact-metadata: write` permission required by `actions/attest` v4
- disable organization-only storage records while retaining GitHub and OCI registry attestations for this personal-account public repository

## Why

The first post-merge workflow was rejected with `startup_failure`. The v4.2.0 action requires the new artifact metadata permission, while its documentation states that storage records themselves are only available for organization-owned repositories.

## Validation

- `actionlint .github/workflows/build.yml`
- `git diff --check`
- official `actions/attest` v4.2.0 permission and storage-record requirements verified