### PR TITLE
Strip frankenphp file capability and drop root in the SSR image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,10 @@ FROM oven/bun:1.3-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a0277a
 
 WORKDIR /app
 
-# bootstrap/ssr is produced by `vp run build:ssr` on the runner.
-COPY --link bootstrap/ssr ./bootstrap/ssr
+# bootstrap/ssr is produced by `vp run build:ssr` on the runner, under
+# `umask 077` (build.yml) — the bundle lands 0600 in the context, so it
+# must be chowned to bun or the non-root server cannot read it.
+COPY --link --chown=1000:1000 bootstrap/ssr ./bootstrap/ssr
 
 # The base image defaults to root; the bundled `bun` user (uid 1000) is
 # enough to serve SSR (read-only bundle, port 13714).

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,14 @@ RUN mkdir -p \
     bootstrap/cache \
     && chown -R www-data:www-data storage bootstrap/cache
 
+# The serversideup base grants cap_net_bind_service to frankenphp (bind <1024).
+# Octane listens on 8000, and the file capability makes execve fail with
+# "Operation not permitted" under no_new_privs (PSS restricted,
+# allowPrivilegeEscalation: false). A plain cp does not preserve xattrs,
+# which strips the capability without needing libcap2-bin.
+RUN cp /usr/local/bin/frankenphp /tmp/frankenphp \
+    && mv /tmp/frankenphp /usr/local/bin/frankenphp
+
 USER www-data
 
 ############################################
@@ -62,6 +70,10 @@ WORKDIR /app
 
 # bootstrap/ssr is produced by `vp run build:ssr` on the runner.
 COPY --link bootstrap/ssr ./bootstrap/ssr
+
+# The base image defaults to root; the bundled `bun` user (uid 1000) is
+# enough to serve SSR (read-only bundle, port 13714).
+USER bun
 
 EXPOSE 13714
 


### PR DESCRIPTION
Companion of gitops#44/#45 (PSS-restricted rollout, same fix as pingcrm#60).

- `app` target: serversideup sets `cap_net_bind_service=+ep` on `/usr/local/bin/frankenphp`; Octane binds 8000 so the cap is useless, and under `allowPrivilegeEscalation: false` (no_new_privs) the kernel refuses to exec a binary with file capabilities → the hardened pod crash-loops. `cp` drops xattrs → capability stripped, no libcap2-bin.
- `ssr` target: was running as **root** (oven/bun default); now `USER bun` (uid 1000) — the SSR bundle is read-only, nothing needs root.

After this image is deployed by Image Automation, the gitops fadogen manifests get the full restricted securityContext (runAsNonRoot, seccomp RuntimeDefault, drop ALL, no privilege escalation) without the interim escape hatch pingcrm needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)