### PR TITLE
Pin the exact PHP version tag on the serversideup base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # rebuild of the tag lands as a reviewable Dependabot PR (tag + digest kept
 # in sync). PHP version bumps stay deliberate: Dockerfile + setup-php in
 # build.yml + composer.json must move together.
-FROM serversideup/php:8.5-frankenphp@sha256:a0f4447da7612f9bca3c982d0cf33a607cbddf828f4b96a44bfa9f6f037007b6 AS base
+FROM serversideup/php:8.5.8-frankenphp@sha256:a0f4447da7612f9bca3c982d0cf33a607cbddf828f4b96a44bfa9f6f037007b6 AS base
 
 USER root
 


### PR DESCRIPTION
## Résumé
- `8.5-frankenphp` → `8.5.8-frankenphp`, même digest (vérifié sur Docker Hub : `sha256:a0f4447d…`) — aucun changement d'image, seul le tag devient explicite.
- Renovate suivra désormais les patches PHP (8.5.8 → 8.5.9) comme tels.
- Décision d'audit du 22/07 : on attend le bump FrankenPHP ≥ 1.12.5 côté serversideup (fuite d'ID de session en mode worker) — il arrivera par bump de ce digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)