### PR TITLE
Use shared Renovate digest policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>fouteox/renovate-config",
-    "github>fouteox/renovate-config:apps",
-    "docker:pinDigests"
+    "github>fouteox/renovate-config:apps"
   ]
 }


### PR DESCRIPTION
## What changed

Remove the local trailing `docker:pinDigests` preset. Docker digest pinning is now owned by the shared default preset in [fouteox/renovate-config#5](https://github.com/fouteox/renovate-config/pull/5).

## Why

Preset order matters in Renovate. Keeping `docker:pinDigests` after the shared preset would override the narrow `zizmor-action` exception and recreate the impossible `pinDigest` branch that currently fails in the Dependency Dashboard.

This does not disable digest pinning: the shared preset still enables it globally and excludes only `github-actions` / `uses-with` / `ghcr.io/zizmorcore/zizmor`.

## Validation

- JSON parsing: passed
- `renovate-config-validator --strict --no-global` with Renovate 43.278.5 and Node 24.11.1: passed
- lookup dry run against this repository's real GitHub workflow using the exact shared preset branch: resolved successfully, no `pinDigest` update, zizmor dependency `updates: []`

## Merge order

Merge [the shared preset PR](https://github.com/fouteox/renovate-config/pull/5) first, then this PR.