### PR TITLE
Préparer la configuration Renovate self-hosted

### DIFF
--- a/renovate-self-hosted.json
+++ b/renovate-self-hosted.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Configuration spécifique à Fadogen pour Renovate self-hosted. La politique commune est fournie par fouteox/renovate-runner."
+}


### PR DESCRIPTION
## Objectif

Préparer le cutover de Fadogen vers fouteox/renovate-runner sans interrompre le service Mend-hosted actuel.

## Changement

- ajoute renovate-self-hosted.json, volontairement ignoré par Mend et par le runner actuel ;
- aucune surcharge locale n’est nécessaire aujourd’hui ;
- ne contient aucune référence au preset public ;
- documente que la politique commune sera injectée depuis le checkout de confiance de renovate-runner.

Cette PR ne change donc encore aucun comportement. Le runner sélectionnera explicitement ce fichier dans une étape ultérieure, après validation dry-run.

## Vérifications

- parité JSON avec les éventuelles règles locales de renovate.json ;
- renovate-config-validator --strict --no-global avec l’image exacte Renovate 44.37.1 épinglée par le runner ;
- git diff --check.