### PR TITLE
Retirer le preset Renovate public de Fadogen

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>fouteox/renovate-config",
-    "github>fouteox/renovate-config:apps"
-  ]
+  "description": "Configuration spécifique à Fadogen pour Renovate self-hosted. La politique commune est fournie par fouteox/renovate-runner."
 }


### PR DESCRIPTION
## Objet

Retirer de Fadogen les dernières références au preset public `fouteox/renovate-config`, en première phase de la fermeture du dépôt public.

## Absence de changement de comportement

Le runner self-hosted exige et lit toujours `renovate-self-hosted.json` en priorité. Cette PR rend le fichier standard `renovate.json` strictement identique à ce fichier actif :

- aucune règle Renovate ne change ;
- la politique commune reste injectée depuis le checkout privé revu de `fouteox/renovate-runner` ;
- aucun fichier actif n'est supprimé pendant cette phase de compatibilité.

Une PR ultérieure fera converger le runner vers le nom standard `renovate.json`, puis supprimera `renovate-self-hosted.json`.

## Validation

- comparaison octet pour octet des deux configurations ;
- `jq empty renovate.json renovate-self-hosted.json` ;
- validation stricte des deux configurations dans l'image Renovate exacte `44.39.1@sha256:00699dedb6d44bf645e3f0a98729bcdb660a660f1952a53d9592d3a127088b11`, en lecture seule et sans réseau ;
- `vendor/bin/pint --dirty` ;
- `git diff --check`.

## Gate de fusion

Ne pas fusionner avant deux exécutions Footeox consécutives déclenchées par `schedule` et qualifiées après le merge de renovate-runner#54.