### PR TITLE
Supprimer la configuration Renovate dupliquée

### DIFF
--- a/renovate-self-hosted.json
+++ b/renovate-self-hosted.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Configuration spécifique à Fadogen pour Renovate self-hosted. La politique commune est fournie par fouteox/renovate-runner."
-}


### PR DESCRIPTION
## Résumé

- supprime renovate-self-hosted.json, désormais inutilisé ;
- conserve renovate.json comme configuration standard du dépôt ;
- ne modifie aucun code, lockfile ni workflow.

Le runner central a déjà basculé sur la découverte standard et son préflight authentifié lit renovate.json. Les deux fichiers étaient strictement identiques avant cette suppression.

## Validation

- jq empty renovate.json
- renovate-config-validator --strict --no-global renovate.json
- image exacte du runner : Renovate 44.39.2, digest sha256:e6b93e709ca64495ab9307350b260064276ee02d15c6886387fd2d42c926623b
- aucune référence restante au fichier supprimé ou au preset public
- git diff --check