### PR TITLE
chore(ci): make zizmor policy comment durable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,9 @@ jobs:
         with:
           persist-credentials: false
 
-      # 1.26.1 = dernière version saine du manifeste embarqué par l'action
-      # v0.6.0 (jamais 1.27.0 : fuite de credentials, GHSA-f42p-wjw5-97qh) ;
-      # repasser à >= 1.28.0 à la prochaine release de zizmor-action.
+      # Renovate met à jour atomiquement le SHA de l'action et l'input version.
+      # Le manifeste embarqué résout cette version vers une image tag@digest ;
+      # la politique du runner interdit Zizmor 1.27.0 (GHSA-f42p-wjw5-97qh).
       # Bloquant via annotations + exit codes ; le mode SARIF
       # (advanced-security) ne fait jamais échouer le job.
       - name: Audit workflows with zizmor


### PR DESCRIPTION
## Contexte

La PR Renovate #72 met désormais à jour atomiquement `zizmor-action` v0.6.2 et Zizmor 1.29.0. Le commentaire actuel décrit encore le contournement temporaire qui fixait le moteur à 1.26.1 en attendant une action compatible ; il deviendrait faux après ce changement.

## Changement

- remplace l'explication temporaire par une invariant durable : SHA de l'action et input `version` regroupés par Renovate ;
- documente la résolution de la version vers une image `tag@digest` par le manifeste embarqué ;
- conserve l'interdiction explicite de Zizmor 1.27.0 liée à `GHSA-f42p-wjw5-97qh`.

Aucune référence exécutable ni dépendance ne change dans cette PR.

## Validation

- diff limité aux trois lignes de commentaire de `.github/workflows/ci.yml` ;
- `git diff --check` vert ;
- `actionlint .github/workflows/ci.yml` vert.

Une fois cette PR fusionnée, le writer Renovate pourra rebaser #72 sur `main` et conserver un unique commit bot contenant uniquement la mise à jour atomique de l'action et du moteur.

## Sources officielles

- [zizmor-action v0.6.2](https://github.com/zizmorcore/zizmor-action/releases/tag/v0.6.2)
- [Avis de sécurité Zizmor 1.27.0](https://github.com/zizmorcore/zizmor/security/advisories/GHSA-f42p-wjw5-97qh)
