### PR TITLE
Harden Bun SSR runtime with distroless 1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,10 +202,43 @@ jobs:
               '\''
             '
 
-          docker run --rm --entrypoint sh "$ssr_image" -euc '
-            bun --version
-            find bootstrap/ssr -maxdepth 1 -type f -name "*.js" -print -quit | grep -q .
+          docker run --rm "$ssr_image" --version
+          docker run --rm "$ssr_image" --eval '
+            const bundle = Bun.file("bootstrap/ssr/app.js");
+
+            if (!await bundle.exists() || bundle.size === 0) {
+              console.error("Missing or empty SSR bundle");
+              process.exit(1);
+            }
           '
+
+          ssr_container="$(docker run --detach "$ssr_image")"
+          cleanup_ssr() {
+            docker rm --force "$ssr_container" >/dev/null 2>&1 || true
+          }
+          trap cleanup_ssr EXIT
+
+          ssr_ready=false
+          for _ in {1..10}; do
+            if docker logs "$ssr_container" 2>&1 | grep -Fq 'Inertia SSR server started.'; then
+              ssr_ready=true
+              break
+            fi
+
+            if [[ "$(docker inspect --format '{{.State.Running}}' "$ssr_container")" != "true" ]]; then
+              break
+            fi
+
+            sleep 1
+          done
+
+          if [[ "$ssr_ready" != "true" ]]; then
+            docker logs "$ssr_container"
+            exit 1
+          fi
+
+          cleanup_ssr
+          trap - EXIT
 
   zizmor:
     name: zizmor (audit workflows)

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,19 +65,20 @@ USER www-data
 ############################################
 # SSR Image
 ############################################
-FROM oven/bun:1.3-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a0277a8f939ae4dfc9db6f AS ssr
+FROM oven/bun:1.4-distroless@sha256:a8919d4a092a234f7184ac6d3960a2d860fea73e034709e1752a7d0de09913f8 AS ssr
 
 WORKDIR /app
 
 # bootstrap/ssr is produced by `vp run build:ssr` on the runner, under
 # `umask 077` (build.yml) — the bundle lands 0600 in the context, so it
-# must be chowned to bun or the non-root server cannot read it.
+# must be chowned to the runtime user or the non-root server cannot read it.
 COPY --link --chown=1000:1000 bootstrap/ssr ./bootstrap/ssr
 
-# The base image defaults to root; the bundled `bun` user (uid 1000) is
-# enough to serve SSR (read-only bundle, port 13714).
-USER bun
+# Keep the numeric non-root identity enforced by the GitOps deployment. Numeric
+# IDs do not depend on a shell or a named /etc/passwd entry in distroless.
+USER 1000:1000
 
 EXPOSE 13714
 
-CMD ["bun", "bootstrap/ssr/app.js"]
+ENTRYPOINT ["/usr/local/bin/bun"]
+CMD ["bootstrap/ssr/app.js"]


### PR DESCRIPTION
## Summary

- replace the Bun SSR runtime with the official `1.4-distroless` image pinned to its immutable multi-platform digest
- retain numeric non-root UID/GID `1000:1000`, matching the live GitOps `securityContext`, and make the Bun exec-form entrypoint explicit
- replace the shell-dependent SSR smoke test with distroless-compatible bundle checks and a real startup-readiness assertion

## Security rationale

Bun officially publishes a distroless variant, and Docker recommends a minimal production base to reduce attack surface.

Current Trivy 0.74.0 results with the same vulnerability database and `--ignore-unfixed`:

- current `1.3-debian`: 39 fixable HIGH, 0 CRITICAL
- Renovate #71 `1.4-debian`: 36 fixable HIGH, 0 CRITICAL
- proposed `1.4-distroless`: 0 fixable HIGH/CRITICAL
- locally built final SSR image: 0 fixable HIGH/CRITICAL

The pinned index digest is `sha256:a8919d4a092a234f7184ac6d3960a2d860fea73e034709e1752a7d0de09913f8`. It currently resolves to official `linux/amd64` and `linux/arm64` manifests with OCI provenance attestations tied to Bun release `bun-v1.4.0`.

The numeric UID/GID deliberately remains `1000:1000`: the production Fadogen Deployment already enforces that identity, while distroless does not require a matching named passwd entry. This keeps the rollout compatible with the existing read-only bundle ownership and avoids a coupled GitOps cutover.

This supersedes the intent of #71 without merging its Debian runtime.

Official references:

- https://bun.sh/docs/installation
- https://docs.docker.com/build/building/best-practices/
- https://github.com/oven-sh/bun/releases/tag/bun-v1.4.0

## Verification

- `actionlint .github/workflows/ci.yml`
- `vp run format:check`
- `vp run lint:check`
- `vp run types`
- `composer test:lint`
- `composer test:types`
- `./vendor/bin/pest --parallel` (10 tests, 18 assertions)
- local Buildx build of target `ssr` under OrbStack
- container config verified as non-root `1000:1000`, matching the live GitOps deployment
- bundle check, default process startup, and `Inertia SSR server started.` readiness log verified
- final image scanned with Trivy 0.74.0 pinned by digest

The exact coverage command is left to CI because the local PHP runtime does not have PCOV; the same test suite passes locally without coverage.