### PR TITLE
Verify Bun provenance and multi-arch vulnerabilities

### DIFF
--- a/.github/scripts/compare-base-vulnerabilities.sh
+++ b/.github/scripts/compare-base-vulnerabilities.sh
@@ -23,6 +23,24 @@ previous_ref=${PREVIOUS_IMAGE_REF:-}
 work_dir=$(mktemp -d)
 cache_dir=${TRIVY_CACHE_DIR:-"$work_dir/trivy-cache"}
 
+run_trivy() {
+    if [[ -z "${TRIVY_IMAGE_REF:-}" ]]; then
+        trivy "$@"
+        return
+    fi
+
+    mkdir -p "$cache_dir"
+    docker run --rm \
+        --read-only \
+        --tmpfs /tmp:rw,nosuid,nodev,noexec \
+        --cap-drop ALL \
+        --security-opt no-new-privileges:true \
+        --user "$(id -u):$(id -g)" \
+        --volume "$work_dir:$work_dir" \
+        --volume "$cache_dir:$cache_dir" \
+        "$TRIVY_IMAGE_REF" "$@"
+}
+
 cleanup() {
     rm -rf "$work_dir"
 }
@@ -58,7 +76,7 @@ for architecture in amd64 arm64; do
     current_report="$work_dir/current-$architecture.json"
     introduced_report="$work_dir/introduced-$architecture.json"
 
-    trivy image \
+    run_trivy image \
         --cache-dir "$cache_dir" \
         --quiet \
         --scanners vuln \
@@ -69,7 +87,7 @@ for architecture in amd64 arm64; do
         --platform "linux/$architecture" \
         "$previous_ref"
 
-    trivy image \
+    run_trivy image \
         --cache-dir "$cache_dir" \
         --quiet \
         --scanners vuln \

--- a/.github/scripts/scan-bun-base-vulnerabilities.sh
+++ b/.github/scripts/scan-bun-base-vulnerabilities.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+extract_image_ref() {
+    awk '
+        $1 == "FROM" && $2 ~ /^oven\/bun:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
+            references[++count] = $2
+        }
+        END {
+            if (count != 1) {
+                printf "Expected exactly one digest-pinned Bun base in %s, found %d.\n", FILENAME, count > "/dev/stderr"
+                exit 1
+            }
+
+            print references[1]
+        }
+    ' "$1"
+}
+
+current_ref=${CURRENT_IMAGE_REF:-}
+work_dir=$(mktemp -d)
+cache_dir=${TRIVY_CACHE_DIR:-"$work_dir/trivy-cache"}
+
+run_trivy() {
+    if [[ -z "${TRIVY_IMAGE_REF:-}" ]]; then
+        trivy "$@"
+        return
+    fi
+
+    mkdir -p "$cache_dir"
+    docker run --rm \
+        --read-only \
+        --tmpfs /tmp:rw,nosuid,nodev,noexec \
+        --cap-drop ALL \
+        --security-opt no-new-privileges:true \
+        --user "$(id -u):$(id -g)" \
+        --volume "$work_dir:$work_dir" \
+        --volume "$cache_dir:$cache_dir" \
+        "$TRIVY_IMAGE_REF" "$@"
+}
+
+cleanup() {
+    rm -rf "$work_dir"
+}
+
+trap cleanup EXIT
+
+if [[ -z "$current_ref" ]]; then
+    current_ref=$(extract_image_ref Dockerfile)
+fi
+
+for architecture in amd64 arm64; do
+    report="$work_dir/current-$architecture.json"
+
+    run_trivy image \
+        --cache-dir "$cache_dir" \
+        --quiet \
+        --scanners vuln \
+        --severity HIGH,CRITICAL \
+        --ignore-unfixed \
+        --format json \
+        --output "$report" \
+        --platform "linux/$architecture" \
+        "$current_ref"
+
+    if ! jq -e '[.Results[]?.Vulnerabilities[]?] | length == 0' "$report" >/dev/null; then
+        echo "::error title=Fixable HIGH/CRITICAL vulnerabilities in Bun::linux/$architecture contains fixable HIGH/CRITICAL vulnerabilities."
+        jq -r '
+            .Results[]?.Vulnerabilities[]?
+            | "\(.Severity) \(.VulnerabilityID) \(.PkgName) \(.InstalledVersion) -> \(.FixedVersion)"
+        ' "$report"
+        exit 1
+    fi
+
+    echo "No fixable HIGH/CRITICAL vulnerability in the Bun base on linux/$architecture."
+done

--- a/.github/scripts/tests/fixtures/attestation-amd64-wrong-subject.json
+++ b/.github/scripts/tests/fixtures/attestation-amd64-wrong-subject.json
@@ -1,0 +1,16 @@
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.docker.attestation.manifest.v1+json",
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:ba1080495a4b00fe5a2ca45633066630cb312be3b42f9b68a531b845412bb949",
+      "annotations": {
+        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+      }
+    }
+  ],
+  "subject": {
+    "digest": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  }
+}

--- a/.github/scripts/tests/fixtures/attestation-amd64.json
+++ b/.github/scripts/tests/fixtures/attestation-amd64.json
@@ -1,0 +1,16 @@
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.docker.attestation.manifest.v1+json",
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:ba1080495a4b00fe5a2ca45633066630cb312be3b42f9b68a531b845412bb949",
+      "annotations": {
+        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+      }
+    }
+  ],
+  "subject": {
+    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+  }
+}

--- a/.github/scripts/tests/fixtures/attestation-arm64-inconsistent.json
+++ b/.github/scripts/tests/fixtures/attestation-arm64-inconsistent.json
@@ -1,0 +1,16 @@
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.docker.attestation.manifest.v1+json",
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:a79dbae07407118469a62206b03ee0d037fb1001232986f6e1b7a29f0e457660",
+      "annotations": {
+        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+      }
+    }
+  ],
+  "subject": {
+    "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+  }
+}

--- a/.github/scripts/tests/fixtures/attestation-arm64.json
+++ b/.github/scripts/tests/fixtures/attestation-arm64.json
@@ -1,0 +1,16 @@
+{
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.docker.attestation.manifest.v1+json",
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:56fa64ea9ae6f941c2e8cd118f05bab627830821e2c698541f0e1c952896ecc8",
+      "annotations": {
+        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+      }
+    }
+  ],
+  "subject": {
+    "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+  }
+}

--- a/.github/scripts/tests/fixtures/index-inconsistent.json
+++ b/.github/scripts/tests/fixtures/index-inconsistent.json
@@ -1,0 +1,41 @@
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "platform": {
+        "os": "linux",
+        "architecture": "amd64"
+      }
+    },
+    {
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "platform": {
+        "os": "linux",
+        "architecture": "arm64"
+      }
+    },
+    {
+      "digest": "sha256:f8db884e1e2a0d588446f91af303733aab88afc3bbe7af438fe22ffbfeb13a9f",
+      "platform": {
+        "os": "unknown",
+        "architecture": "unknown"
+      },
+      "annotations": {
+        "vnd.docker.reference.type": "attestation-manifest",
+        "vnd.docker.reference.digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    },
+    {
+      "digest": "sha256:bc3245881e67d1f259c09a7182573612ecb74aa3de2a4784695a1ab5e709e4b2",
+      "platform": {
+        "os": "unknown",
+        "architecture": "unknown"
+      },
+      "annotations": {
+        "vnd.docker.reference.type": "attestation-manifest",
+        "vnd.docker.reference.digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    }
+  ]
+}

--- a/.github/scripts/tests/fixtures/index-malformed.json
+++ b/.github/scripts/tests/fixtures/index-malformed.json
@@ -1,0 +1,23 @@
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "platform": {
+        "os": "linux",
+        "architecture": "amd64"
+      }
+    },
+    {
+      "digest": "sha256:f8db884e1e2a0d588446f91af303733aab88afc3bbe7af438fe22ffbfeb13a9f",
+      "platform": {
+        "os": "unknown",
+        "architecture": "unknown"
+      },
+      "annotations": {
+        "vnd.docker.reference.type": "attestation-manifest",
+        "vnd.docker.reference.digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    }
+  ]
+}

--- a/.github/scripts/tests/fixtures/index-mismatched-attestation.json
+++ b/.github/scripts/tests/fixtures/index-mismatched-attestation.json
@@ -1,0 +1,41 @@
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "platform": {
+        "os": "linux",
+        "architecture": "amd64"
+      }
+    },
+    {
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "platform": {
+        "os": "linux",
+        "architecture": "arm64"
+      }
+    },
+    {
+      "digest": "sha256:d9703c8eea6f7f3099d80d24724b97d24d7d391f891a7d54df3acada0a687dfe",
+      "platform": {
+        "os": "unknown",
+        "architecture": "unknown"
+      },
+      "annotations": {
+        "vnd.docker.reference.type": "attestation-manifest",
+        "vnd.docker.reference.digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    },
+    {
+      "digest": "sha256:dceafb0867e02a0f6f801e3ffbda1a23643dcfde87572c4080361c6c06b2ec87",
+      "platform": {
+        "os": "unknown",
+        "architecture": "unknown"
+      },
+      "annotations": {
+        "vnd.docker.reference.type": "attestation-manifest",
+        "vnd.docker.reference.digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    }
+  ]
+}

--- a/.github/scripts/tests/fixtures/index-valid.json
+++ b/.github/scripts/tests/fixtures/index-valid.json
@@ -1,0 +1,41 @@
+{
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "platform": {
+        "os": "linux",
+        "architecture": "amd64"
+      }
+    },
+    {
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "platform": {
+        "os": "linux",
+        "architecture": "arm64"
+      }
+    },
+    {
+      "digest": "sha256:f8db884e1e2a0d588446f91af303733aab88afc3bbe7af438fe22ffbfeb13a9f",
+      "platform": {
+        "os": "unknown",
+        "architecture": "unknown"
+      },
+      "annotations": {
+        "vnd.docker.reference.type": "attestation-manifest",
+        "vnd.docker.reference.digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    },
+    {
+      "digest": "sha256:dceafb0867e02a0f6f801e3ffbda1a23643dcfde87572c4080361c6c06b2ec87",
+      "platform": {
+        "os": "unknown",
+        "architecture": "unknown"
+      },
+      "annotations": {
+        "vnd.docker.reference.type": "attestation-manifest",
+        "vnd.docker.reference.digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    }
+  ]
+}

--- a/.github/scripts/tests/fixtures/jobs.json
+++ b/.github/scripts/tests/fixtures/jobs.json
@@ -1,0 +1,14 @@
+{
+  "jobs": [
+    {
+      "name": "Release to Dockerhub (distroless, -distroless)",
+      "status": "completed",
+      "conclusion": "success",
+      "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "runner_group_name": "GitHub Actions",
+      "labels": [
+        "ubuntu-latest"
+      ]
+    }
+  ]
+}

--- a/.github/scripts/tests/fixtures/provenance-amd64.json
+++ b/.github/scripts/tests/fixtures/provenance-amd64.json
@@ -1,0 +1,54 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "name": "pkg:docker/oven/bun@1.4.0-distroless?platform=linux%2Famd64",
+      "digest": {
+        "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    }
+  ],
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md",
+      "externalParameters": {
+        "configSource": {
+          "path": "Dockerfile"
+        },
+        "request": {
+          "args": {
+            "build-arg:BUN_VERSION": "bun-v1.4.0",
+            "label:org.opencontainers.image.revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "label:org.opencontainers.image.source": "https://github.com/oven-sh/bun",
+            "label:org.opencontainers.image.version": "1.4.0-distroless"
+          }
+        }
+      },
+      "internalParameters": {
+        "github_event_name": "release",
+        "github_ref": "refs/tags/bun-v1.4.0",
+        "github_repository": "oven-sh/bun",
+        "github_run_id": "123456",
+        "github_run_attempt": "1"
+      }
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://github.com/oven-sh/bun/actions/runs/123456/attempts/1"
+      },
+      "metadata": {
+        "startedOn": "2026-08-20T14:09:26Z",
+        "finishedOn": "2026-08-20T14:11:27Z",
+        "buildkit_metadata": {
+          "vcs": {
+            "localdir:context": "dockerhub/distroless",
+            "localdir:dockerfile": "dockerhub/distroless",
+            "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source": "https://github.com/oven-sh/bun"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/scripts/tests/fixtures/provenance-arm64-inconsistent.json
+++ b/.github/scripts/tests/fixtures/provenance-arm64-inconsistent.json
@@ -1,0 +1,54 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "name": "pkg:docker/oven/bun@1.4.0-distroless?platform=linux%2Farm64",
+      "digest": {
+        "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    }
+  ],
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md",
+      "externalParameters": {
+        "configSource": {
+          "path": "Dockerfile"
+        },
+        "request": {
+          "args": {
+            "build-arg:BUN_VERSION": "bun-v1.4.0",
+            "label:org.opencontainers.image.revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "label:org.opencontainers.image.source": "https://github.com/oven-sh/bun",
+            "label:org.opencontainers.image.version": "1.4.0-distroless"
+          }
+        }
+      },
+      "internalParameters": {
+        "github_event_name": "release",
+        "github_ref": "refs/tags/bun-v1.4.0",
+        "github_repository": "oven-sh/bun",
+        "github_run_id": "999999",
+        "github_run_attempt": "1"
+      }
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://github.com/oven-sh/bun/actions/runs/999999/attempts/1"
+      },
+      "metadata": {
+        "startedOn": "2026-08-20T14:09:26Z",
+        "finishedOn": "2026-08-20T14:11:27Z",
+        "buildkit_metadata": {
+          "vcs": {
+            "localdir:context": "dockerhub/distroless",
+            "localdir:dockerfile": "dockerhub/distroless",
+            "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source": "https://github.com/oven-sh/bun"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/scripts/tests/fixtures/provenance-arm64.json
+++ b/.github/scripts/tests/fixtures/provenance-arm64.json
@@ -1,0 +1,54 @@
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "subject": [
+    {
+      "name": "pkg:docker/oven/bun@1.4.0-distroless?platform=linux%2Farm64",
+      "digest": {
+        "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+      }
+    }
+  ],
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md",
+      "externalParameters": {
+        "configSource": {
+          "path": "Dockerfile"
+        },
+        "request": {
+          "args": {
+            "build-arg:BUN_VERSION": "bun-v1.4.0",
+            "label:org.opencontainers.image.revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "label:org.opencontainers.image.source": "https://github.com/oven-sh/bun",
+            "label:org.opencontainers.image.version": "1.4.0-distroless"
+          }
+        }
+      },
+      "internalParameters": {
+        "github_event_name": "release",
+        "github_ref": "refs/tags/bun-v1.4.0",
+        "github_repository": "oven-sh/bun",
+        "github_run_id": "123456",
+        "github_run_attempt": "1"
+      }
+    },
+    "runDetails": {
+      "builder": {
+        "id": "https://github.com/oven-sh/bun/actions/runs/123456/attempts/1"
+      },
+      "metadata": {
+        "startedOn": "2026-08-20T14:09:26Z",
+        "finishedOn": "2026-08-20T14:11:27Z",
+        "buildkit_metadata": {
+          "vcs": {
+            "localdir:context": "dockerhub/distroless",
+            "localdir:dockerfile": "dockerhub/distroless",
+            "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "source": "https://github.com/oven-sh/bun"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/scripts/tests/fixtures/release.json
+++ b/.github/scripts/tests/fixtures/release.json
@@ -1,0 +1,7 @@
+{
+  "tag_name": "bun-v1.4.0",
+  "target_commitish": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "draft": false,
+  "prerelease": false,
+  "published_at": "2026-08-20T14:07:21Z"
+}

--- a/.github/scripts/tests/fixtures/run.json
+++ b/.github/scripts/tests/fixtures/run.json
@@ -1,0 +1,15 @@
+{
+  "status": "completed",
+  "conclusion": "failure",
+  "event": "release",
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "head_branch": "bun-v1.4.0",
+  "repository": {
+    "full_name": "oven-sh/bun"
+  },
+  "head_repository": {
+    "full_name": "oven-sh/bun"
+  },
+  "path": ".github/workflows/release.yml",
+  "run_attempt": 1
+}

--- a/.github/scripts/tests/fixtures/trivy-clean.json
+++ b/.github/scripts/tests/fixtures/trivy-clean.json
@@ -1,0 +1,8 @@
+{
+  "Results": [
+    {
+      "Target": "fixture",
+      "Vulnerabilities": null
+    }
+  ]
+}

--- a/.github/scripts/tests/fixtures/trivy-vulnerable.json
+++ b/.github/scripts/tests/fixtures/trivy-vulnerable.json
@@ -1,0 +1,16 @@
+{
+  "Results": [
+    {
+      "Target": "fixture",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2099-0001",
+          "PkgName": "fixture-package",
+          "InstalledVersion": "1.0.0",
+          "FixedVersion": "1.0.1",
+          "Severity": "HIGH"
+        }
+      ]
+    }
+  ]
+}

--- a/.github/scripts/tests/mocks/curl
+++ b/.github/scripts/tests/mocks/curl
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+fixture_digest() {
+    sha256sum "$1" | awk '{ print "sha256:" $1 }'
+}
+
+url=
+
+for argument in "$@"; do
+    if [[ "$argument" == https://* ]]; then
+        url=$argument
+    fi
+done
+
+if [[ "$url" == "https://auth.docker.io/token" ]]; then
+    printf '%s\n' '{"token":"fixture-token"}'
+    exit 0
+fi
+
+if [[ "$url" == https://registry-1.docker.io/v2/oven/bun/blobs/sha256:* ]]; then
+    requested_digest=${url##*/}
+
+    for fixture in "$FIXTURES_DIR"/provenance-*.json; do
+        if [[ "$(fixture_digest "$fixture")" == "$requested_digest" ]]; then
+            output_path=
+
+            for ((index = 1; index <= $#; index++)); do
+                if [[ "${!index}" == "--output" ]]; then
+                    output_index=$((index + 1))
+                    output_path=${!output_index}
+                    break
+                fi
+            done
+
+            if [[ -n "$output_path" ]]; then
+                cp "$fixture" "$output_path"
+            else
+                cat "$fixture"
+            fi
+
+            exit 0
+        fi
+    done
+fi
+
+echo "Unexpected curl invocation: $*" >&2
+exit 1

--- a/.github/scripts/tests/mocks/docker
+++ b/.github/scripts/tests/mocks/docker
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+fixture_digest() {
+    sha256sum "$1" | awk '{ print "sha256:" $1 }'
+}
+
+if [[ "$1" == "buildx" && "$2" == "imagetools" && "$3" == "inspect" ]]; then
+    reference=$4
+
+    if [[ "$reference" == oven/bun:* ]]; then
+        case "${SCENARIO:?}" in
+            valid)
+                fixture="index-valid.json"
+                ;;
+            malformed-index)
+                fixture="index-malformed.json"
+                ;;
+            mismatched-attestation)
+                fixture="index-mismatched-attestation.json"
+                ;;
+            inconsistent-architectures)
+                fixture="index-inconsistent.json"
+                ;;
+            *)
+                echo "Unexpected provenance scenario: $SCENARIO" >&2
+                exit 1
+                ;;
+        esac
+
+        cat "$FIXTURES_DIR/$fixture"
+        exit 0
+    fi
+
+    if [[ "$reference" == oven/bun@sha256:* ]]; then
+        requested_digest=${reference#oven/bun@}
+
+        for fixture in "$FIXTURES_DIR"/attestation-*.json; do
+            if [[ "$(fixture_digest "$fixture")" == "$requested_digest" ]]; then
+                cat "$fixture"
+                exit 0
+            fi
+        done
+
+        echo "Unknown fixture attestation: $requested_digest" >&2
+        exit 1
+    fi
+fi
+
+if [[ "$1" == "run" ]]; then
+    output_path=
+
+    for ((index = 1; index <= $#; index++)); do
+        if [[ "${!index}" == "--output" ]]; then
+            output_index=$((index + 1))
+            output_path=${!output_index}
+            break
+        fi
+    done
+
+    if [[ -z "$output_path" ]]; then
+        echo "Mock Trivy invocation has no --output argument." >&2
+        exit 1
+    fi
+
+    case "${SCENARIO:?}" in
+        scan-clean)
+            cp "$FIXTURES_DIR/trivy-clean.json" "$output_path"
+            ;;
+        scan-vulnerable)
+            cp "$FIXTURES_DIR/trivy-vulnerable.json" "$output_path"
+            ;;
+        *)
+            echo "Unexpected scan scenario: $SCENARIO" >&2
+            exit 1
+            ;;
+    esac
+
+    exit 0
+fi
+
+echo "Unexpected docker invocation: $*" >&2
+exit 1

--- a/.github/scripts/tests/mocks/gh
+++ b/.github/scripts/tests/mocks/gh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+if [[ "$1" != "api" ]]; then
+    echo "Unexpected gh invocation: $*" >&2
+    exit 1
+fi
+
+if [[ "$2" == "--paginate" ]]; then
+    endpoint=$3
+else
+    endpoint=$2
+fi
+
+case "$endpoint" in
+    repos/oven-sh/bun/releases/tags/bun-v1.4.0)
+        cat "$FIXTURES_DIR/release.json"
+        ;;
+    repos/oven-sh/bun/actions/runs/123456)
+        cat "$FIXTURES_DIR/run.json"
+        ;;
+    repos/oven-sh/bun/actions/runs/123456/jobs)
+        cat "$FIXTURES_DIR/jobs.json"
+        ;;
+    *)
+        echo "Unexpected GitHub API fixture: $endpoint" >&2
+        exit 1
+        ;;
+esac

--- a/.github/scripts/tests/test-bun-policy.sh
+++ b/.github/scripts/tests/test-bun-policy.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+test_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+scripts_dir=$(cd -- "$test_dir/.." && pwd)
+fixtures_dir="$test_dir/fixtures"
+mocks_dir="$test_dir/mocks"
+test_count=0
+
+fixture_digest() {
+    sha256sum "$1" | awk '{ print "sha256:" $1 }'
+}
+
+index_fixture() {
+    case "$1" in
+        valid)
+            printf '%s\n' "$fixtures_dir/index-valid.json"
+            ;;
+        malformed-index)
+            printf '%s\n' "$fixtures_dir/index-malformed.json"
+            ;;
+        mismatched-attestation)
+            printf '%s\n' "$fixtures_dir/index-mismatched-attestation.json"
+            ;;
+        inconsistent-architectures)
+            printf '%s\n' "$fixtures_dir/index-inconsistent.json"
+            ;;
+        *)
+            echo "Unknown test scenario: $1" >&2
+            exit 1
+            ;;
+    esac
+}
+
+run_provenance_scenario() {
+    local scenario=$1
+    local index_digest
+
+    index_digest=$(fixture_digest "$(index_fixture "$scenario")")
+
+    PATH="$mocks_dir:$PATH" \
+        FIXTURES_DIR="$fixtures_dir" \
+        SCENARIO="$scenario" \
+        IMAGE_REF="oven/bun:1.4-distroless@$index_digest" \
+        "$scripts_dir/verify-bun-base.sh"
+}
+
+run_scan_scenario() {
+    local scenario=$1
+
+    PATH="$mocks_dir:$PATH" \
+        FIXTURES_DIR="$fixtures_dir" \
+        SCENARIO="$scenario" \
+        CURRENT_IMAGE_REF="oven/bun:1.4-distroless@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+        TRIVY_IMAGE_REF="ghcr.io/aquasecurity/trivy:fixture@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+        "$scripts_dir/scan-bun-base-vulnerabilities.sh"
+}
+
+expect_success() {
+    local name=$1
+    shift
+    local output
+
+    if ! output=$("$@" 2>&1); then
+        echo "FAIL: $name" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+
+    test_count=$((test_count + 1))
+    echo "PASS: $name"
+}
+
+expect_failure() {
+    local name=$1
+    local expected_message=$2
+    shift 2
+    local output
+
+    if output=$("$@" 2>&1); then
+        echo "FAIL: $name unexpectedly succeeded" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+
+    if [[ -n "$expected_message" ]] && ! grep -Fq "$expected_message" <<< "$output"; then
+        echo "FAIL: $name did not emit the expected diagnostic" >&2
+        printf '%s\n' "$output" >&2
+        exit 1
+    fi
+
+    test_count=$((test_count + 1))
+    echo "PASS: $name"
+}
+
+expect_success \
+    "valid multi-architecture Bun provenance" \
+    run_provenance_scenario valid
+expect_failure \
+    "malformed OCI index" \
+    "" \
+    run_provenance_scenario malformed-index
+expect_failure \
+    "attestation subject mismatch" \
+    "" \
+    run_provenance_scenario mismatched-attestation
+expect_failure \
+    "cross-architecture provenance inconsistency" \
+    "Bun provenance is inconsistent across architectures." \
+    run_provenance_scenario inconsistent-architectures
+expect_success \
+    "clean Trivy reports" \
+    run_scan_scenario scan-clean
+expect_failure \
+    "fixable HIGH vulnerability" \
+    "CVE-2099-0001" \
+    run_scan_scenario scan-vulnerable
+
+echo "All $test_count Bun policy regression tests passed."

--- a/.github/scripts/verify-bun-base.sh
+++ b/.github/scripts/verify-bun-base.sh
@@ -274,6 +274,8 @@ jq -s -e \
             and .status == "completed"
             and .conclusion == "success"
             and .head_sha == $source_sha
+            and .runner_group_name == "GitHub Actions"
+            and (.labels | index("ubuntu-latest")) != null
         )
     ] | length == 1
     ' \

--- a/.github/scripts/verify-bun-base.sh
+++ b/.github/scripts/verify-bun-base.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+dockerfile=${1:-Dockerfile}
+image_ref=${IMAGE_REF:-}
+
+if [[ -z "$image_ref" ]]; then
+    image_ref=$(awk '
+        $1 == "FROM" && $2 ~ /^oven\/bun:[^@[:space:]]+@sha256:[0-9a-f]{64}$/ {
+            references[++count] = $2
+        }
+        END {
+            if (count != 1) {
+                printf "Expected exactly one digest-pinned Bun base, found %d.\n", count > "/dev/stderr"
+                exit 1
+            }
+
+            print references[1]
+        }
+    ' "$dockerfile")
+fi
+
+if [[ ! "$image_ref" =~ ^oven/bun:([0-9]+)\.([0-9]+)-distroless@(sha256:[0-9a-f]{64})$ ]]; then
+    echo "Expected one digest-pinned oven/bun:<major>.<minor>-distroless base in $dockerfile." >&2
+    exit 1
+fi
+
+declared_major=${BASH_REMATCH[1]}
+declared_minor=${BASH_REMATCH[2]}
+declared_index_digest=${BASH_REMATCH[3]}
+repository=oven/bun
+work_dir=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$work_dir"
+}
+
+trap cleanup EXIT
+
+index_file="$work_dir/index.json"
+docker buildx imagetools inspect "$image_ref" --raw > "$index_file"
+
+actual_index_digest="sha256:$(sha256sum "$index_file" | awk '{ print $1 }')"
+
+if [[ "$actual_index_digest" != "$declared_index_digest" ]]; then
+    echo "Index digest mismatch: expected $declared_index_digest, got $actual_index_digest." >&2
+    exit 1
+fi
+
+jq -e '
+    .mediaType == "application/vnd.oci.image.index.v1+json"
+    and ([
+        .manifests[]
+        | select(
+            .platform.os == "linux"
+            and (.platform.architecture == "amd64" or .platform.architecture == "arm64")
+        )
+    ] | length == 2)
+    and ([
+        .manifests[]
+        | select(.annotations["vnd.docker.reference.type"] == "attestation-manifest")
+    ] | length == 2)
+' "$index_file" >/dev/null
+
+registry_token=$(curl \
+    --fail \
+    --silent \
+    --show-error \
+    --location \
+    --retry 3 \
+    --retry-all-errors \
+    --get \
+    --data-urlencode service=registry.docker.io \
+    --data-urlencode "scope=repository:$repository:pull" \
+    https://auth.docker.io/token | jq -er .token)
+
+release_version=
+source_sha=
+run_id=
+run_attempt=
+
+for architecture in amd64 arm64; do
+    platform_digest=$(jq -er \
+        --arg architecture "$architecture" \
+        '.manifests[]
+            | select(.platform.os == "linux" and .platform.architecture == $architecture)
+            | .digest' \
+        "$index_file")
+
+    attestation_digest=$(jq -er \
+        --arg platform_digest "$platform_digest" \
+        '.manifests[]
+            | select(
+                .annotations["vnd.docker.reference.type"] == "attestation-manifest"
+                and .annotations["vnd.docker.reference.digest"] == $platform_digest
+            )
+            | .digest' \
+        "$index_file")
+
+    attestation_file="$work_dir/attestation-$architecture.json"
+    docker buildx imagetools inspect "$repository@$attestation_digest" --raw > "$attestation_file"
+
+    actual_attestation_digest="sha256:$(sha256sum "$attestation_file" | awk '{ print $1 }')"
+
+    if [[ "$actual_attestation_digest" != "$attestation_digest" ]]; then
+        echo "Attestation manifest digest mismatch for linux/$architecture." >&2
+        exit 1
+    fi
+
+    jq -e \
+        --arg platform_digest "$platform_digest" \
+        '
+        .mediaType == "application/vnd.oci.image.manifest.v1+json"
+        and .artifactType == "application/vnd.docker.attestation.manifest.v1+json"
+        and .subject.digest == $platform_digest
+        and ([
+            .layers[]
+            | select(
+                .mediaType == "application/vnd.in-toto+json"
+                and .annotations["in-toto.io/predicate-type"] == "https://slsa.dev/provenance/v1"
+            )
+        ] | length == 1)
+        ' \
+        "$attestation_file" >/dev/null
+
+    provenance_digest=$(jq -er '
+        .layers[]
+        | select(
+            .mediaType == "application/vnd.in-toto+json"
+            and .annotations["in-toto.io/predicate-type"] == "https://slsa.dev/provenance/v1"
+        )
+        | .digest
+    ' "$attestation_file")
+
+    provenance_file="$work_dir/provenance-$architecture.json"
+    curl \
+        --fail \
+        --silent \
+        --show-error \
+        --location \
+        --retry 3 \
+        --retry-all-errors \
+        --header "Authorization: Bearer $registry_token" \
+        "https://registry-1.docker.io/v2/$repository/blobs/$provenance_digest" \
+        --output "$provenance_file"
+
+    actual_provenance_digest="sha256:$(sha256sum "$provenance_file" | awk '{ print $1 }')"
+
+    if [[ "$actual_provenance_digest" != "$provenance_digest" ]]; then
+        echo "Provenance blob digest mismatch for linux/$architecture." >&2
+        exit 1
+    fi
+
+    platform_digest_hex=${platform_digest#sha256:}
+    architecture_version=$(jq -er \
+        '.predicate.buildDefinition.externalParameters.request.args["build-arg:BUN_VERSION"]
+            | capture("^bun-v(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)$")
+            | .version' \
+        "$provenance_file")
+
+    if [[ "$architecture_version" != "$declared_major.$declared_minor."* ]]; then
+        echo "Bun provenance version $architecture_version does not match the declared $declared_major.$declared_minor tag." >&2
+        exit 1
+    fi
+
+    architecture_source_sha=$(jq -er \
+        '.predicate.buildDefinition.externalParameters.request.args["label:org.opencontainers.image.revision"]' \
+        "$provenance_file")
+    architecture_run_id=$(jq -er \
+        '.predicate.buildDefinition.internalParameters.github_run_id | tostring' \
+        "$provenance_file")
+    architecture_run_attempt=$(jq -er \
+        '.predicate.buildDefinition.internalParameters.github_run_attempt | tostring' \
+        "$provenance_file")
+
+    jq -e \
+        --arg architecture "$architecture" \
+        --arg platform_digest "$platform_digest_hex" \
+        --arg release_version "$architecture_version" \
+        --arg source_sha "$architecture_source_sha" \
+        --arg run_id "$architecture_run_id" \
+        --arg run_attempt "$architecture_run_attempt" \
+        '
+        ._type == "https://in-toto.io/Statement/v1"
+        and .predicateType == "https://slsa.dev/provenance/v1"
+        and any(
+            .subject[]?;
+            .digest.sha256 == $platform_digest
+            and (.name | endswith("-distroless?platform=linux%2F" + $architecture))
+        )
+        and .predicate.buildDefinition.buildType == "https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md"
+        and .predicate.buildDefinition.externalParameters.configSource.path == "Dockerfile"
+        and .predicate.buildDefinition.externalParameters.request.args["build-arg:BUN_VERSION"] == ("bun-v" + $release_version)
+        and .predicate.buildDefinition.externalParameters.request.args["label:org.opencontainers.image.revision"] == $source_sha
+        and .predicate.buildDefinition.externalParameters.request.args["label:org.opencontainers.image.source"] == "https://github.com/oven-sh/bun"
+        and .predicate.buildDefinition.externalParameters.request.args["label:org.opencontainers.image.version"] == ($release_version + "-distroless")
+        and .predicate.buildDefinition.internalParameters.github_event_name == "release"
+        and .predicate.buildDefinition.internalParameters.github_ref == ("refs/tags/bun-v" + $release_version)
+        and .predicate.buildDefinition.internalParameters.github_repository == "oven-sh/bun"
+        and (.predicate.buildDefinition.internalParameters.github_run_id | tostring) == $run_id
+        and (.predicate.buildDefinition.internalParameters.github_run_attempt | tostring) == $run_attempt
+        and .predicate.runDetails.builder.id == ("https://github.com/oven-sh/bun/actions/runs/" + $run_id + "/attempts/" + $run_attempt)
+        and .predicate.runDetails.metadata.startedOn != null
+        and .predicate.runDetails.metadata.finishedOn != null
+        and .predicate.runDetails.metadata.buildkit_metadata.vcs["localdir:context"] == "dockerhub/distroless"
+        and .predicate.runDetails.metadata.buildkit_metadata.vcs["localdir:dockerfile"] == "dockerhub/distroless"
+        and .predicate.runDetails.metadata.buildkit_metadata.vcs.revision == $source_sha
+        and .predicate.runDetails.metadata.buildkit_metadata.vcs.source == "https://github.com/oven-sh/bun"
+        ' \
+        "$provenance_file" >/dev/null
+
+    if [[ -z "$release_version" ]]; then
+        release_version=$architecture_version
+        source_sha=$architecture_source_sha
+        run_id=$architecture_run_id
+        run_attempt=$architecture_run_attempt
+    elif [[
+        "$architecture_version" != "$release_version"
+        || "$architecture_source_sha" != "$source_sha"
+        || "$architecture_run_id" != "$run_id"
+        || "$architecture_run_attempt" != "$run_attempt"
+    ]]; then
+        echo "Bun provenance is inconsistent across architectures." >&2
+        exit 1
+    fi
+
+    echo "Verified linux/$architecture Bun provenance from run $architecture_run_id attempt $architecture_run_attempt."
+done
+
+release_file="$work_dir/release.json"
+gh api "repos/oven-sh/bun/releases/tags/bun-v$release_version" > "$release_file"
+
+jq -e \
+    --arg release_version "$release_version" \
+    --arg source_sha "$source_sha" \
+    '
+    .tag_name == ("bun-v" + $release_version)
+    and .target_commitish == $source_sha
+    and .draft == false
+    and .prerelease == false
+    and .published_at != null
+    ' \
+    "$release_file" >/dev/null
+
+run_file="$work_dir/run.json"
+gh api "repos/oven-sh/bun/actions/runs/$run_id" > "$run_file"
+
+jq -e \
+    --arg release_version "$release_version" \
+    --arg source_sha "$source_sha" \
+    --arg run_attempt "$run_attempt" \
+    '
+    .status == "completed"
+    and .event == "release"
+    and .head_sha == $source_sha
+    and .head_branch == ("bun-v" + $release_version)
+    and .repository.full_name == "oven-sh/bun"
+    and .head_repository.full_name == "oven-sh/bun"
+    and .path == ".github/workflows/release.yml"
+    and (.run_attempt | tostring) == $run_attempt
+    ' \
+    "$run_file" >/dev/null
+
+jobs_file="$work_dir/jobs.json"
+gh api --paginate "repos/oven-sh/bun/actions/runs/$run_id/jobs" > "$jobs_file"
+
+jq -s -e \
+    --arg source_sha "$source_sha" \
+    '
+    [.[].jobs[]
+        | select(
+            .name == "Release to Dockerhub (distroless, -distroless)"
+            and .status == "completed"
+            and .conclusion == "success"
+            and .head_sha == $source_sha
+        )
+    ] | length == 1
+    ' \
+    "$jobs_file" >/dev/null
+
+echo "Verified pinned Bun index $declared_index_digest from official release bun-v$release_version."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
+      - name: Test Bun image policy scripts
+        run: .github/scripts/tests/test-bun-policy.sh
+
       - name: Verify pinned ServerSideUp provenance
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,41 +41,33 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: .github/scripts/verify-serversideup-base.sh
 
-      - name: Install checksum-verified Trivy
+      - name: Verify pinned Bun provenance
         env:
-          TRIVY_VERSION: 0.72.0
-        run: |
-          case "$RUNNER_ARCH" in
-            X64)
-              archive="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
-              checksum=bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea
-              ;;
-            ARM64)
-              archive="trivy_${TRIVY_VERSION}_Linux-ARM64.tar.gz"
-              checksum=2ca2c023109c2db6b2b77366b6717291452d4531167377d95c79547f0c8e3467
-              ;;
-            *)
-              echo "Unsupported runner architecture: $RUNNER_ARCH" >&2
-              exit 1
-              ;;
-          esac
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/verify-bun-base.sh
 
-          archive_path="$RUNNER_TEMP/$archive"
-          curl --fail --silent --show-error --location \
-            --retry 3 --retry-all-errors \
-            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${archive}" \
-            --output "$archive_path"
-          printf '%s  %s\n' "$checksum" "$archive_path" | sha256sum --check -
-          tar -xzf "$archive_path" -C "$RUNNER_TEMP" trivy
-          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
-          "$RUNNER_TEMP/trivy" --version
+      - name: Verify pinned Trivy runtime
+        run: |
+          # renovate: datasource=docker depName=ghcr.io/aquasecurity/trivy
+          image_ref="ghcr.io/aquasecurity/trivy:0.74.0@sha256:62b1e65e8869bc4b4c6aa4fa2b21595256c7c2f6018a9d9ad61caf87187c1969"
+          docker run --rm --read-only --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            "$image_ref" --version
+          echo "TRIVY_IMAGE_REF=$image_ref" >> "$GITHUB_ENV"
 
       - name: Reject newly introduced fixable HIGH/CRITICAL vulnerabilities
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ github.token }}
           TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+          TRIVY_IMAGE_REF: ${{ env.TRIVY_IMAGE_REF }}
         run: .github/scripts/compare-base-vulnerabilities.sh
+
+      - name: Reject fixable HIGH/CRITICAL vulnerabilities in the Bun base
+        env:
+          TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+          TRIVY_IMAGE_REF: ${{ env.TRIVY_IMAGE_REF }}
+        run: .github/scripts/scan-bun-base-vulnerabilities.sh
 
   quality:
     name: quality


### PR DESCRIPTION
## Objectif

Rendre durable le contrôle effectué lors du passage du runtime SSR à Bun distroless : la CI doit prouver la provenance du digest et bloquer les vulnérabilités corrigibles HIGH/CRITICAL sur les deux architectures du cluster.

## Changements

- vérifie le digest exact de l index OCI Bun et ses manifestes linux/amd64 + linux/arm64 ;
- vérifie pour chaque architecture la provenance SLSA v1 liée au digest, la version, le commit, la release officielle et le job Docker distroless producteur sur runner GitHub-hosted ;
- exécute Trivy 0.74.0 depuis son image GHCR officielle épinglée par tag + digest ;
- laisse le manager regex central Renovate suivre atomiquement le tag et le digest Trivy ;
- exécute Trivy sans capabilities, avec no-new-privileges, filesystem en lecture seule et utilisateur non-root ;
- scanne le runtime Bun sur amd64 et arm64 à chaque PR ;
- conserve le contrôle différentiel existant sur ServerSideUp en le faisant utiliser le même runtime Trivy immuable ;
- teste les chemins de succès et échec avec des fixtures hors réseau avant les contrôles live.

## Vérifications

- six tests de régression : chemin valide, index malformé, sujet attestation incohérent, divergence multiarchitecture, rapport propre et vulnérabilité HIGH corrigible ;
- provenance Bun live vérifiée sur amd64 et arm64 pour le digest a8919d4… ;
- release officielle bun-v1.4.0 et job Release to Dockerhub (distroless, -distroless) reliés au commit 34cbb9a… ;
- Trivy 0.74.0 : zéro vulnérabilité corrigible HIGH/CRITICAL sur amd64 et arm64 ;
- test négatif live : ancienne image oven/bun:1.3-debian rejetée avec 39 vulnérabilités corrigibles HIGH ;
- ShellCheck ;
- Actionlint sur ci.yml ;
- git diff --check ;
- extraction du tag et du digest Trivy reproduite avec le regex manager central ;
- GitHub Actions 32823548432 entièrement vert sur le head 01d7723.

## Sources officielles

- [Bun v1.4.0](https://github.com/oven-sh/bun/releases/tag/bun-v1.4.0)
- [Job officiel distroless](https://github.com/oven-sh/bun/actions/runs/32378241872/job/96455271132)
- [Dockerfile distroless officiel](https://github.com/oven-sh/bun/blob/main/dockerhub/distroless/Dockerfile)
- [Trivy v0.74.0](https://github.com/aquasecurity/trivy/releases/tag/v0.74.0)
- [Images conteneur officielles Trivy](https://github.com/aquasecurity/trivy/blob/main/docs/getting-started/installation.md)
- [Provenance SLSA BuildKit](https://docs.docker.com/build/metadata/attestations/slsa-provenance/)

## Limite explicite

Le workflow de release Bun global contient des jobs sans rapport avec le build de cette image et se termine en échec. Le contrôle ne prétend donc pas que tout ce workflow est vert : il exige que le job producteur distroless précis soit terminé avec succès, sur un runner GitHub-hosted, avec le même SHA et la même tentative que la provenance. Toute modification future de la chaîne officielle échouera en mode fermé et devra être réauditée.